### PR TITLE
add note for troubleshooting poetry installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ using [poetry](https://python-poetry.org/).
 poetry install
 ```
 
+*(Note: if installing the dependencies hangs, you may need to disable the keyring while installing: `POETRY_KEYRING_ENABLED=false poetry install`)*
+
 Create a correct `.env` file.
 
 ```shell


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #3 

Poetry seems to require using the system keyring when installing dependencies. This can cause the install to hang if for whatever reason Poetry isn't able to access the keyring.

This PR adds a brief note to the README with a workaround for that case, setting the `POETRY_KEYRING_ENABLED` envvar to False.